### PR TITLE
Filter sequences in `extract_random_seqs_from_genome` return file by N count

### DIFF
--- a/R/extract_random_seqs_from_genome.R
+++ b/R/extract_random_seqs_from_genome.R
@@ -15,6 +15,7 @@
 #' @param subject_genome file path to the \code{fasta} file storing the subject genome.
 #' @param file_name a name of the output \code{fasta} file that will store the sequences of the randomly
 #' sampled loci.
+#' @param n_max a non-negative integer giving the maximum number of allowed Ns in each sequence.
 #' @param append shall new random sequences be added to an existing \code{file_name} (\code{append = TRUE})
 #'  or should an exosting \code{file_name} be removed before storing new random sequences (\code{append = FALSE}; Default)?  
 #' @author Hajk-Georg Drost
@@ -27,7 +28,8 @@ extract_random_seqs_from_genome <-
            interval_width,
            subject_genome,
            file_name = NULL,
-           append = FALSE) {
+           append = FALSE,
+           n_max = NULL) {
     
     if (!file.exists(subject_genome))
       stop(
@@ -145,13 +147,19 @@ extract_random_seqs_from_genome <-
                 )
               )
               
+              # set n_max when null and count N in each sequence
+              if (is.null(n_max)) n_max <- interval_width + 1
+              nn <- Biostrings::vcountPattern('N', seqs_plus@unlistData)
+              seqs <- seqs_plus@unlistData[nn <= n_max]
+              
+              # subset sequences
               Biostrings::writeXStringSet(
-                seqs_plus@unlistData,
+                seqs,
                 filepath = file_name,
                 format = "fasta",
                 append = TRUE
               )
-              
+
             } else {
               message("  -> No random sequences were chosen from the plus strand of ", chr_names[j])
             }
@@ -177,8 +185,15 @@ extract_random_seqs_from_genome <-
                 )
               )
               
+              # set n_max when null and count N in each sequence
+              if (is.null(n_max)) n_max <- interval_width + 1
+              nn <- Biostrings::vcountPattern('N', seqs_minus@unlistData)
+              
+              # subset sequences
+              seqs <- seqs_minus@unlistData[nn <= n_max]
+              
               Biostrings::writeXStringSet(
-                seqs_minus@unlistData,
+                seqs,
                 filepath = file_name,
                 format = "fasta",
                 append = TRUE
@@ -191,4 +206,5 @@ extract_random_seqs_from_genome <-
         
     message("Sequence extraction process of random loci finished without any problems.")
     return(file_name)
+    
   }

--- a/man/extract_random_seqs_from_genome.Rd
+++ b/man/extract_random_seqs_from_genome.Rd
@@ -5,7 +5,8 @@
 \title{Extract random loci from a genome of interest}
 \usage{
 extract_random_seqs_from_genome(size, replace = TRUE, prob = NULL,
-  interval_width, subject_genome, file_name = NULL, append = FALSE)
+  interval_width, subject_genome, file_name = NULL, append = FALSE,
+  n_max = NULL)
 }
 \arguments{
 \item{size}{a non-negative integer giving the number of loci that shall be sampled.}
@@ -23,6 +24,8 @@ sampled loci.}
 
 \item{append}{shall new random sequences be added to an existing \code{file_name} (\code{append = TRUE})
 or should an exosting \code{file_name} be removed before storing new random sequences (\code{append = FALSE}; Default)?}
+
+\item{n_max}{a non-negative integer giving the maximum number of allowed Ns in each sequence.}
 }
 \description{
 This function allows users to specify a number of sequences

--- a/tests/testthat/test-extract_random_seqs_from_genome.R
+++ b/tests/testthat/test-extract_random_seqs_from_genome.R
@@ -1,0 +1,36 @@
+context('test extract_random_seqs_from_genome')
+
+test_that("No filtering Ns", {
+    genome_fa <- system.file('seqs', 'sbj_aa.fa', package = "metablastr")
+    output_fa <- tempfile()
+    
+    set.seed(123)
+    extract_random_seqs_from_genome(subject_genome = genome_fa,
+                                    interval_width = 10,
+                                    size = 20,
+                                    file_name = output_fa)
+    
+    rand_seq <- Biostrings::readAAStringSet(output_fa)
+
+    expect_equal(length(rand_seq), 20)
+    expect_true(all(lengths(rand_seq) == 10))
+})
+
+test_that("Filtering sequences with count N > n_max", {
+    
+    genome_fa <- system.file('seqs', 'sbj_aa.fa', package = "metablastr")
+    output_fa <- tempfile()
+    
+    set.seed(123)
+    extract_random_seqs_from_genome(subject_genome = genome_fa,
+                                    interval_width = 10,
+                                    size = 20,
+                                    file_name = output_fa,
+                                    n_max = 1)
+    
+    rand_seq <- Biostrings::readAAStringSet(output_fa)
+    nn <- Biostrings::vcountPattern('N', rand_seq)
+    
+    expect_equal(length(rand_seq), sum(nn <= 1))
+    expect_true(all(lengths(rand_seq) == 10))
+})


### PR DESCRIPTION
* Add an argument `n_max` to give the maximum allowed number
* Count the number of Ns in each generated sequence
* Write-off the sequence if it contains Ns > `n_max`

related #3 